### PR TITLE
disable hover in mobile and make placeholder

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -23,7 +23,10 @@ export default function Header() {
         </Link>
 
         {/* 検索フォームと検索ボタン */}
-        <SearchBar className="hidden md:inline-block" />
+        <SearchBar
+          className="hidden md:inline-block"
+          placeholeder="Seach Onave"
+        />
         <SearchButton
           className="ml-auto mr-[5%] md:hidden"
           onClick={() => {
@@ -43,12 +46,12 @@ export default function Header() {
           >
             <ArrowLeftIcon className="size-5" />
           </button>
-          <SearchBar className="max-w-[60%]" />
+          <SearchBar className="max-w-[60%]" placeholeder="Search Onave" />
         </header>
 
         {/* ログインボタン */}
         <Link href="/login">
-          <button className="rounded-full bg-neutral-700 px-4 py-2 text-sm text-white hover:bg-red-700">
+          <button className="rounded-full bg-neutral-700 px-4 py-2 text-sm text-white hover:bg-red-700 active:bg-red-700">
             ログイン
           </button>
         </Link>

--- a/src/components/parts/searchbar.tsx
+++ b/src/components/parts/searchbar.tsx
@@ -2,6 +2,7 @@ import {MagnifyingGlassIcon} from "@heroicons/react/24/outline";
 
 interface Props {
   className?: string;
+  placeholeder?: string;
 }
 
 export default function SearchBar(props: Props) {
@@ -12,6 +13,7 @@ export default function SearchBar(props: Props) {
         <input
           type="search"
           className="max-w-[100%] rounded-2xl p-2 ps-8 shadow focus:outline-none"
+          placeholder={props.placeholeder}
         />
       </form>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,4 +2,7 @@
 
 module.exports = {
   content: ["./src/**/*.{ts,tsx}"],
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
 };


### PR DESCRIPTION
## やったこと
- モバイルでのログインボタン挙動改善
  - モバイルでのホバー無効化
  - アクティブによるエフェクト追加
 
- 検索フォームにプレースホルダーの追加

## その他
モバイルでのホバー無効化はTailwindのfuture設定を使用した。